### PR TITLE
fix for change in R 4.2.0 regarding length of conditions > 1

### DIFF
--- a/R/EUtils.R
+++ b/R/EUtils.R
@@ -35,7 +35,7 @@ EUtilsQuery <- function(query,type="esearch",db="pubmed",...){
 	}
 	else{
 		WhichArgs <- pmatch(names(ArgList),OPTIONS)	
-		if(any(is.na(WhichArgs))||sapply(WhichArgs,length)>1)
+		if(any(is.na(WhichArgs))||any(sapply(WhichArgs,length)>1))
 			stop("Error in specified limits.")
 		names(ArgList) <- OPTIONS[WhichArgs]
 		if(all(names(ArgList)!="retmax"))


### PR DESCRIPTION
add `base::any` to offending conditional in `EUtilsQuery`.

Before R 4.2.0 the `any` was implied afaik.